### PR TITLE
Remove calls to broadcast

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -28,7 +28,7 @@ jobs:
         conda install openmpi pymumps ipopt --no-update-deps
         pip install mpi4py
         pip install git+https://github.com/pyutilib/pyutilib.git
-        git clone https://github.com/pyomo/pyomo.git
+        git clone --single-branch --branch pynumero https://github.com/michaelbynum/pyomo.git
         cd pyomo/
         python setup.py develop
         pyomo download-extensions

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -37,7 +37,7 @@ jobs:
         python setup.py develop
     - name: Test with nose
       run: |
-        nosetests -v -a '!parallel' -a n_procs=all -a n_procs=1 --nologcapture --with-coverage --cover-package=parapint --with-doctest --doctest-extension=.rst  --cover-xml parapint
+        nosetests -v -a '!parallel' -a n_procs=all -a n_procs=1 --with-coverage --cover-package=parapint --with-doctest --doctest-extension=.rst  --cover-xml parapint
         coverage report -m
         mpirun -np 2 -oversubscribe nosetests -a parallel,n_procs=all -a parallel,n_procs=2 parapint
         mpirun -np 3 -oversubscribe nosetests -a parallel,n_procs=all -a parallel,n_procs=3 parapint

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -28,7 +28,7 @@ jobs:
         conda install openmpi pymumps ipopt --no-update-deps
         pip install mpi4py
         pip install git+https://github.com/pyutilib/pyutilib.git
-        git clone --single-branch --branch pynumero https://github.com/michaelbynum/pyomo.git
+        git clone https://github.com/pyomo/pyomo.git
         cd pyomo/
         python setup.py develop
         pyomo download-extensions

--- a/parapint/interfaces/schur_complement/mpi_sc_ip_interface.py
+++ b/parapint/interfaces/schur_complement/mpi_sc_ip_interface.py
@@ -134,7 +134,6 @@ class MPIDynamicSchurComplementInteriorPointInterface(DynamicSchurComplementInte
         self._setup_block_vectors()
         self._setup_jacs()
         self._setup_kkt_and_rhs_structure()
-        self._broadcast()
 
     def _build_mpi_block_matrix(self, extra_row: bool = False, extra_col: bool = False) -> MPIBlockMatrix:
         if extra_row:
@@ -155,7 +154,8 @@ class MPIDynamicSchurComplementInteriorPointInterface(DynamicSchurComplementInte
         mat = MPIBlockMatrix(nbrows=nrows,
                              nbcols=ncols,
                              rank_ownership=rank_ownership,
-                             mpi_comm=self._comm)
+                             mpi_comm=self._comm,
+                             assert_correct_owners=False)
         return mat
 
     def _build_mpi_block_vector(self, extra_block: bool = False) -> MPIBlockVector:
@@ -168,7 +168,8 @@ class MPIDynamicSchurComplementInteriorPointInterface(DynamicSchurComplementInte
             rank_ownership[ndx] = self._ownership_map[ndx]
         vec = MPIBlockVector(nblocks=n,
                              rank_owner=rank_ownership,
-                             mpi_comm=self._comm)
+                             mpi_comm=self._comm,
+                             assert_correct_owners=False)
         return vec
 
     def _setup(self, start_t: float, end_t: float):
@@ -209,53 +210,6 @@ class MPIDynamicSchurComplementInteriorPointInterface(DynamicSchurComplementInte
         for ndx in range(self._num_time_blocks):
             self._link_forward_coupling_matrices[ndx] = self._build_link_forward_coupling_matrix(ndx)
             self._link_backward_coupling_matrices[ndx] = self._build_link_backward_coupling_matrix(ndx)
-
-    def _broadcast(self):
-        self._primals_lb.broadcast_block_sizes()
-        self._primals_ub.broadcast_block_sizes()
-
-        self._ineq_lb.broadcast_block_sizes()
-        self._ineq_ub.broadcast_block_sizes()
-
-        self._init_primals.broadcast_block_sizes()
-        self._primals.broadcast_block_sizes()
-        self._delta_primals.broadcast_block_sizes()
-
-        self._init_slacks.broadcast_block_sizes()
-        self._slacks.broadcast_block_sizes()
-        self._delta_slacks.broadcast_block_sizes()
-
-        self._init_duals_eq.broadcast_block_sizes()
-        self._duals_eq.broadcast_block_sizes()
-        self._delta_duals_eq.broadcast_block_sizes()
-
-        self._init_duals_ineq.broadcast_block_sizes()
-        self._duals_ineq.broadcast_block_sizes()
-        self._delta_duals_ineq.broadcast_block_sizes()
-
-        self._init_duals_primals_lb.broadcast_block_sizes()
-        self._duals_primals_lb.broadcast_block_sizes()
-        self._delta_duals_primals_lb.broadcast_block_sizes()
-
-        self._init_duals_primals_ub.broadcast_block_sizes()
-        self._duals_primals_ub.broadcast_block_sizes()
-        self._delta_duals_primals_ub.broadcast_block_sizes()
-
-        self._init_duals_slacks_lb.broadcast_block_sizes()
-        self._duals_slacks_lb.broadcast_block_sizes()
-        self._delta_duals_slacks_lb.broadcast_block_sizes()
-
-        self._init_duals_slacks_ub.broadcast_block_sizes()
-        self._duals_slacks_ub.broadcast_block_sizes()
-        self._delta_duals_slacks_ub.broadcast_block_sizes()
-
-        self._eq_resid.broadcast_block_sizes()
-        self._ineq_resid.broadcast_block_sizes()
-        self._grad_objective.broadcast_block_sizes()
-        self._jac_eq.broadcast_block_sizes()
-        self._jac_ineq.broadcast_block_sizes()
-        self._kkt.broadcast_block_sizes()
-        self._rhs.broadcast_block_sizes()
 
     def n_primals(self) -> int:
         res = sum(nlp.n_primals() for nlp in self._nlps.values())

--- a/parapint/interfaces/schur_complement/mpi_sc_ip_interface.py
+++ b/parapint/interfaces/schur_complement/mpi_sc_ip_interface.py
@@ -155,7 +155,7 @@ class MPIDynamicSchurComplementInteriorPointInterface(DynamicSchurComplementInte
                              nbcols=ncols,
                              rank_ownership=rank_ownership,
                              mpi_comm=self._comm,
-                             assert_correct_owners=False)
+                             assert_correct_owners=True)
         return mat
 
     def _build_mpi_block_vector(self, extra_block: bool = False) -> MPIBlockVector:

--- a/parapint/interfaces/schur_complement/mpi_sc_ip_interface.py
+++ b/parapint/interfaces/schur_complement/mpi_sc_ip_interface.py
@@ -155,7 +155,7 @@ class MPIDynamicSchurComplementInteriorPointInterface(DynamicSchurComplementInte
                              nbcols=ncols,
                              rank_ownership=rank_ownership,
                              mpi_comm=self._comm,
-                             assert_correct_owners=True)
+                             assert_correct_owners=False)
         return mat
 
     def _build_mpi_block_vector(self, extra_block: bool = False) -> MPIBlockVector:


### PR DESCRIPTION
MPIBlockVector and MPIBlockMatrix no longer need to call broadcast_block_sizes