### PR TITLE
adding stale linking variables explicitly to pyomoNLP

### DIFF
--- a/parapint/interfaces/interface.py
+++ b/parapint/interfaces/interface.py
@@ -240,12 +240,12 @@ class BaseInteriorPointInterface(ABC):
 
 
 class InteriorPointInterface(BaseInteriorPointInterface):
-    def __init__(self, pyomo_model):
+    def __init__(self, pyomo_model, export_nonlinear_variables = []):
         if type(pyomo_model) is str:
             # Assume argument is the name of an nl file
             self._nlp = ampl_nlp.AmplNLP(pyomo_model)
         else:
-            self._nlp = pyomo_nlp.PyomoNLP(pyomo_model, nl_file_options={'skip_trivial_constraints': True})
+            self._nlp = pyomo_nlp.PyomoNLP(pyomo_model, nl_file_options={'skip_trivial_constraints': True, 'export_nonlinear_variables': export_nonlinear_variables})
         self._slacks = self.init_slacks()
 
         # set the init_duals_primals_lb/ub from ipopt_zL_out, ipopt_zU_out if available

--- a/parapint/interfaces/schur_complement/mpi_sc_ip_interface.py
+++ b/parapint/interfaces/schur_complement/mpi_sc_ip_interface.py
@@ -7,6 +7,7 @@ from pyomo.contrib.pynumero.sparse import BlockVector, BlockMatrix
 import numpy as np
 from typing import Dict, Optional, Sequence
 from pyomo.common.timing import HierarchicalTimer
+from pyomo.common.collections import ComponentSet
 from mpi4py import MPI
 from .sc_ip_interface import DynamicSchurComplementInteriorPointInterface, StochasticSchurComplementInteriorPointInterface
 
@@ -197,9 +198,8 @@ class MPIDynamicSchurComplementInteriorPointInterface(DynamicSchurComplementInte
                                                            start_t=_start_t,
                                                            end_t=_end_t,
                                                            add_init_conditions=add_init_conditions)
-            start_stale_names = [v.name for v in start_states if v.stale]
-            stale_vars = [v for v in start_states if v.stale] + [v for v in end_states if v.stale and v.name not in start_stale_names]
-            self._nlps[ndx] = nlp = InteriorPointInterface(pyomo_model=pyomo_model, export_nonlinear_variables=stale_vars)
+            linking_vars = [v for v in start_states] + [v for v in end_states if v not in ComponentSet(start_states)]
+            self._nlps[ndx] = nlp = InteriorPointInterface(pyomo_model=pyomo_model, export_nonlinear_variables=linking_vars)
             assert len(start_states) == len(end_states)
             if self._num_states is not None:
                 assert self._num_states == len(start_states)

--- a/parapint/interfaces/schur_complement/mpi_sc_ip_interface.py
+++ b/parapint/interfaces/schur_complement/mpi_sc_ip_interface.py
@@ -197,7 +197,9 @@ class MPIDynamicSchurComplementInteriorPointInterface(DynamicSchurComplementInte
                                                            start_t=_start_t,
                                                            end_t=_end_t,
                                                            add_init_conditions=add_init_conditions)
-            self._nlps[ndx] = nlp = InteriorPointInterface(pyomo_model=pyomo_model)
+            start_stale_names = [v.name for v in start_states if v.stale]
+            stale_vars = [v for v in start_states if v.stale] + [v for v in end_states if v.stale and v.name not in start_stale_names]
+            self._nlps[ndx] = nlp = InteriorPointInterface(pyomo_model=pyomo_model, export_nonlinear_variables=stale_vars)
             assert len(start_states) == len(end_states)
             if self._num_states is not None:
                 assert self._num_states == len(start_states)

--- a/parapint/interfaces/schur_complement/sc_ip_interface.py
+++ b/parapint/interfaces/schur_complement/sc_ip_interface.py
@@ -159,7 +159,9 @@ class DynamicSchurComplementInteriorPointInterface(BaseInteriorPointInterface, m
                                                            start_t=_start_t,
                                                            end_t=_end_t,
                                                            add_init_conditions=add_init_conditions)
-            self._nlps[ndx] = nlp = InteriorPointInterface(pyomo_model=pyomo_model)
+            start_stale_names = [v.name for v in start_states if v.stale]
+            stale_vars = [v for v in start_states if v.stale] + [v for v in end_states if v.stale and v.name not in start_stale_names]
+            self._nlps[ndx] = nlp = InteriorPointInterface(pyomo_model=pyomo_model, export_nonlinear_variables=stale_vars)
             assert len(start_states) == len(end_states)
             if self._num_states is not None:
                 assert self._num_states == len(start_states)

--- a/parapint/interfaces/schur_complement/sc_ip_interface.py
+++ b/parapint/interfaces/schur_complement/sc_ip_interface.py
@@ -8,6 +8,7 @@ from pyomo.core.base.block import _BlockData
 from pyomo.core.base.var import _GeneralVarData
 from pyomo.core.base.constraint import _GeneralConstraintData
 from pyomo.common.timing import HierarchicalTimer
+from pyomo.common.collections import ComponentSet
 
 
 class DynamicSchurComplementInteriorPointInterface(BaseInteriorPointInterface, metaclass=ABCMeta):
@@ -159,9 +160,8 @@ class DynamicSchurComplementInteriorPointInterface(BaseInteriorPointInterface, m
                                                            start_t=_start_t,
                                                            end_t=_end_t,
                                                            add_init_conditions=add_init_conditions)
-            start_stale_names = [v.name for v in start_states if v.stale]
-            stale_vars = [v for v in start_states if v.stale] + [v for v in end_states if v.stale and v.name not in start_stale_names]
-            self._nlps[ndx] = nlp = InteriorPointInterface(pyomo_model=pyomo_model, export_nonlinear_variables=stale_vars)
+            linking_vars = [v for v in start_states] + [v for v in end_states if v not in ComponentSet(start_states)]
+            self._nlps[ndx] = nlp = InteriorPointInterface(pyomo_model=pyomo_model, export_nonlinear_variables=linking_vars)
             assert len(start_states) == len(end_states)
             if self._num_states is not None:
                 assert self._num_states == len(start_states)


### PR DESCRIPTION
This addresses the bug where an error is thrown when a linking variable is stale within a time block. The stale linking variables are passed explicitly to the .nl file writer in pyomoNLP, so that they can be found in the _vardata_to_idx map later. In the dynamic Schur interface class, the stale linking variables are selected from the start and end states. There might be a more 'pyomo' way to avoid duplicates when passing the variables, here I did this based on variable name.