### PR TITLE
Improve performance of Schur complement sparsity computation

### DIFF
--- a/parapint/examples/tests/test_examples.py
+++ b/parapint/examples/tests/test_examples.py
@@ -87,7 +87,9 @@ class TestExamples(unittest.TestCase):
 
     @pytest.mark.parallel
     @pytest.mark.medium
-    @pytest.mark.all_proc
+    @pytest.mark.one_proc
+    @pytest.mark.two_proc
+    @pytest.mark.three_proc
     def test_schur_complement_psc(self):
         class Args:
             def __init__(self):

--- a/parapint/linalg/schur_complement/mpi_explicit_schur_complement.py
+++ b/parapint/linalg/schur_complement/mpi_explicit_schur_complement.py
@@ -124,7 +124,9 @@ def _get_all_nonzero_elements_in_sc(border_matrices: Dict[int, _BorderMatrix]):
 
     return nonzero_rows, nonzero_cols
 
-def _get_all_nonzero_elements_in_sc_using_ix(border_matrices: Dict[int, _BorderMatrix], local_block_indices: List[int], num_blocks: int):
+def _get_all_nonzero_elements_in_sc_using_ix(border_matrices: Dict[int, _BorderMatrix],
+                                             local_block_indices: List[int],
+                                             num_blocks: int):
 
     num_nnz_per_local_blocks = np.array([border_matrices[ndx].num_nonzero_rows for ndx in local_block_indices], dtype=np.int64)
     if rank == 0:

--- a/parapint/linalg/schur_complement/mpi_explicit_schur_complement.py
+++ b/parapint/linalg/schur_complement/mpi_explicit_schur_complement.py
@@ -124,6 +124,52 @@ def _get_all_nonzero_elements_in_sc(border_matrices: Dict[int, _BorderMatrix]):
 
     return nonzero_rows, nonzero_cols
 
+def _get_all_nonzero_elements_in_sc_using_ix(border_matrices: Dict[int, _BorderMatrix], local_block_indices: List[int], num_blocks: int):
+
+    num_nnz_per_local_blocks = np.array([border_matrices[ndx].num_nonzero_rows for ndx in local_block_indices], dtype=np.int64)
+    if rank == 0:
+        all_num_nnz_per_block = np.zeros(num_blocks, dtype=np.int64)
+    else:
+        all_num_nnz_per_block = None
+
+    # Collect num. of nonzeros per block in correct order
+    sendcounts = np.array(comm.gather(len(num_nnz_per_local_blocks), 0))
+    comm.Gatherv(sendbuf=num_nnz_per_local_blocks,
+                 recvbuf=(all_num_nnz_per_block, sendcounts),
+                 root=0)
+
+    local_nnzs = np.concatenate([border_matrices[ndx].nonzero_rows for ndx in local_block_indices])
+    sendcounts = np.array(comm.gather(len(local_nnzs), 0))
+    if rank == 0:
+        nnz_indices_vector = np.zeros(sum(sendcounts), dtype=np.int64)
+    else:
+        nnz_indices_vector = None
+
+    # Collect nonzero indices for each block in 1-D array, ordered as above
+    comm.Gatherv(sendbuf=local_nnzs, 
+                 recvbuf=(nnz_indices_vector, sendcounts),
+                 root=0)
+
+    if rank == 0:
+        # Retrieve indices for each block from 1-D array
+        local_indices_vectors = np.split(nnz_indices_vector, np.cumsum(all_num_nnz_per_block))
+        sc_dim = border_matrices[local_block_indices[0]].csr.shape[0]
+        sc = np.zeros((sc_dim, sc_dim), dtype=np.bool_)
+        # Define incidence of SC by sum of cross product for all local block indices
+        for local_indices in local_indices_vectors:
+            sc[np.ix_(local_indices, local_indices)] = True
+        sc = coo_matrix(sc)
+        nonzero_rows = sc.row
+        nonzero_cols = sc.col
+    else:
+        nonzero_rows = np.zeros(0, dtype=np.int64)
+        nonzero_cols = np.zeros(0, dtype=np.int64)
+
+    nonzero_rows = comm.bcast(nonzero_rows, root=0)
+    nonzero_cols = comm.bcast(nonzero_cols, root=0)
+
+    return nonzero_rows, nonzero_cols
+
 
 class MPISchurComplementLinearSolver(LinearSolverInterface):
     """
@@ -225,33 +271,6 @@ class MPISchurComplementLinearSolver(LinearSolverInterface):
 
         return res
 
-    def _get_all_nonzero_elements_in_sc(self):
-        root = 0
-        lsc_components = [self.border_matrices[ndx].nonzero_rows for ndx in self.local_block_indices]
-        # TODO: Not sure if this is the fastest way to reduce lists of arrays
-        #all_components = comm.reduce(lsc_components, root=root)
-        all_components = comm.gather(lsc_components, root=root)
-
-        if rank == root:
-            sc_dim = self.border_matrices[self.local_block_indices[0]].csr.shape[0]
-            sc = np.zeros((sc_dim, sc_dim), dtype=np.bool_)
-            for process_lists in all_components:
-                for components in process_lists:
-            #for components in all_components:
-                    print(components)
-                    sc[np.ix_(components, components)] = True
-            sc = coo_matrix(sc)
-            nonzero_rows = sc.row
-            nonzero_cols = sc.col
-        else:
-            nonzero_rows = np.zeros(0, dtype=np.int64)
-            nonzero_cols = np.zeros(0, dtype=np.int64)
-        
-        nonzero_rows = comm.bcast(nonzero_rows, root=root)
-        nonzero_cols = comm.bcast(nonzero_cols, root=root)
-        
-        return nonzero_rows, nonzero_cols
-
     def _get_sc_structure(self, block_matrix, timer):
         """
         Parameters
@@ -264,10 +283,7 @@ class MPISchurComplementLinearSolver(LinearSolverInterface):
             self.border_matrices[ndx] = _BorderMatrix(block_matrix.get_block(self.block_dim - 1, ndx))
         timer.stop('build_border_matrices')
         timer.start('gather_all_nonzero_elements')
-        _nonzero_rows, _nonzero_cols = _get_all_nonzero_elements_in_sc(self.border_matrices)
-        nonzero_rows, nonzero_cols = self._get_all_nonzero_elements_in_sc()
-        print(f'Rows, cols new: {nonzero_rows}, {nonzero_cols}')
-        print(f'Rows, cols old: {_nonzero_rows}, {_nonzero_cols}')
+        nonzero_rows, nonzero_cols = _get_all_nonzero_elements_in_sc_using_ix(self.border_matrices, self.local_block_indices, self.block_dim - 1)
         timer.stop('gather_all_nonzero_elements')
         timer.start('construct_schur_complement')
         sc_nnz = nonzero_rows.size

--- a/parapint/linalg/schur_complement/tests/test_mpi_explicit_schur_complement.py
+++ b/parapint/linalg/schur_complement/tests/test_mpi_explicit_schur_complement.py
@@ -18,7 +18,9 @@ size = comm.Get_size()
 class TestSchurComplement(unittest.TestCase):
     @pytest.mark.parallel
     @pytest.mark.fast
-    @pytest.mark.all_proc
+    @pytest.mark.one_proc
+    @pytest.mark.two_proc
+    @pytest.mark.three_proc
     def test_mpi_schur_complement(self):
         rank_by_index = list()
         for ndx in range(3):


### PR DESCRIPTION
This addresses the issue that _get_all_nonzero_elements_in_sc was prohibitively slow for large Schur complements (high nnz), specifically caused by the use of sort() in _combine_nonzero_elements. I replaced this by a method which uses np.ix_ to set nonzero indices in the SC.

I left the old implementation for now, because I am not completely sure of the reasoning behind the loop over nested_comms , i.e. if this might be useful in some cases. If so, the two methods would need to be combined.