### PR TITLE
PCG iterative solver for Implicit Schur

### DIFF
--- a/parapint/linalg/__init__.py
+++ b/parapint/linalg/__init__.py
@@ -5,5 +5,4 @@ from .ma27_interface import InteriorPointMA27Interface
 from .mumps_interface import MumpsInterface
 from .schur_complement.explicit_schur_complement import SchurComplementLinearSolver
 from .schur_complement.mpi_explicit_schur_complement import MPISchurComplementLinearSolver
-from .schur_complement.mpi_implicit_schur_tests import MPIImplicitSchurComplementLinearSolver
 from .iterative.pcg import pcg_solve, PcgOptions, LbfgsSamplingOptions, LbfgsApproxOptions

--- a/parapint/linalg/__init__.py
+++ b/parapint/linalg/__init__.py
@@ -5,3 +5,5 @@ from .ma27_interface import InteriorPointMA27Interface
 from .mumps_interface import MumpsInterface
 from .schur_complement.explicit_schur_complement import SchurComplementLinearSolver
 from .schur_complement.mpi_explicit_schur_complement import MPISchurComplementLinearSolver
+from .schur_complement.mpi_implicit_schur_tests import MPIImplicitSchurComplementLinearSolver
+from .iterative.pcg import pcg_solve, PcgOptions, LbfgsSamplingOptions, LbfgsApproxOptions

--- a/parapint/linalg/iterative/pcg.py
+++ b/parapint/linalg/iterative/pcg.py
@@ -1,0 +1,190 @@
+import numpy as np
+import enum
+from scipy.sparse.linalg._isolve.utils import make_system
+from scipy.optimize import LbfgsInvHessProduct
+from typing import Dict
+from pyomo.common.config import ConfigDict, ConfigValue, PositiveFloat, NonNegativeInt, NonNegativeFloat, InEnum
+
+class LbfgsSamplingOptions(enum.Enum):
+    last = 0
+    first = 1
+    uniform = 2
+    disable = -1
+
+class LbfgsApproxOptions(ConfigDict):
+
+    def __init__(self,
+                 description=None,
+                 doc=None,
+                 implicit=False,
+                 implicit_domain=None,
+                 visibility=0):
+        super().__init__(description=description,
+                         doc=doc,
+                         implicit=implicit,
+                         implicit_domain=implicit_domain,
+                         visibility=visibility)
+        self.declare('m', ConfigValue(domain=NonNegativeInt))
+        # TODO: not sure if this is the intended usage
+        self.declare('sampling', ConfigValue(domain=InEnum(LbfgsSamplingOptions)))
+
+        self.m = 10
+        self.sampling = LbfgsSamplingOptions.disable
+
+class PcgOptions(ConfigDict):
+
+    def __init__(self,
+                 description=None,
+                 doc=None,
+                 implicit=False,
+                 implicit_domain=None,
+                 visibility=0):
+        super().__init__(description=description,
+                         doc=doc,
+                         implicit=implicit,
+                         implicit_domain=implicit_domain,
+                         visibility=visibility)
+        self.declare('max_iter', ConfigValue(domain=NonNegativeInt))
+        self.declare('a_tol', ConfigValue(domain=PositiveFloat))
+        self.declare('r_tol', ConfigValue(domain=PositiveFloat))
+        self.declare('lbfgs_sampling_options', ConfigValue(domain=LbfgsApproxOptions))
+
+        self.max_iter = None
+        self.a_tol = 1e-6
+        self.r_tol = 1e-6
+        self.lbfgs_sampling_options = LbfgsApproxOptions()
+
+
+class LbfgsInvHessCollector:
+
+    def __init__(self, approx_options: LbfgsApproxOptions, dim: int):
+        self._sampling_strategy = approx_options.sampling
+        self._m = approx_options.m
+        self._dim = dim
+        self._sk = np.zeros((self._m, self._dim))
+        self._yk = np.zeros((self._m, self._dim))
+        self._counter = 0
+
+        if approx_options.sampling == LbfgsSamplingOptions.uniform:
+            # use first m-1 for uniform samples, last for current
+            # from Morales, J.L. and Nocedal, J. (2000). Automatic preconditioning
+            # by limited memory quasi-newton updating.
+            # SIAM Journal on Optimization, 10(4), 1079-1096.
+            assert self._m % 2 == 1
+            self._l = np.arange(1, (self._m - 1)/2 + 1)
+            self._k_indxs = list(range(0, self._m - 1))
+            self._cycle = 1
+
+    def pop_inv_hessian_approx(self):
+        assert self._counter > 0
+        if self._counter < self._m:
+            ret = LbfgsInvHessProduct(self._sk[:self._counter], self._yk[:self._counter])
+        else:
+            ret = LbfgsInvHessProduct(self._sk, self._yk)
+        self._counter = 0
+        self._sk = np.zeros((self._m, self._dim))
+        self._yk = np.zeros((self._m, self._dim))
+        return ret
+    
+    def update(self, s, y, pcg_iter: int) -> None:
+        if pcg_iter < self._m:
+            self._sk[pcg_iter] = s
+            self._yk[pcg_iter] = y
+            self._counter += 1
+            return None
+        elif self._sampling_strategy == LbfgsSamplingOptions.first:
+            pass
+        elif self._sampling_strategy == LbfgsSamplingOptions.last:
+            self._sk = np.roll(self._sk, -1, axis=0)
+            self._yk = np.roll(self._yk, -1, axis=0)
+        elif self._sampling_strategy == LbfgsSamplingOptions.uniform:
+            _, k_out = self._uniform_sample(pcg_iter)
+            if k_out is not None:
+                self._sk[k_out] = s
+                self._yk[k_out] = y
+        # Always keep last iterate
+        self._sk[-1] = s
+        self._yk[-1] = y
+        self._counter += 1
+        
+    def _uniform_sample(self, k: int):
+        k_indxs = (((self._m - 1)/2) + self._l - 1) * (2 ** self._cycle)
+        in_idx = self._l[np.where(k_indxs == k)]
+        if len(in_idx) == 0:
+            return None, None
+        else:
+            l_out = (2*in_idx[0] - 1) * (2 ** (self._cycle - 1))
+            rem_idx = self._k_indxs.index(int(l_out))
+            self._k_indxs.remove(int(l_out))
+            self._k_indxs.append(k)
+            if in_idx[0] == (self._m - 1)/2:
+                self._cycle += 1
+            return k, rem_idx
+
+
+
+def pcg(A, b, x0=None, M=None, pcg_options: PcgOptions = PcgOptions(),
+        callback=None):
+    """Adaptation of scipy.sparse.linalg.cg
+
+    """
+    maxiter = pcg_options.max_iter
+    atol = pcg_options.a_tol
+    rtol = pcg_options.r_tol
+    hess_approx_options = pcg_options.lbfgs_sampling_options
+    if hess_approx_options.sampling != LbfgsSamplingOptions.disable:
+        inv_hess_collector = LbfgsInvHessCollector(hess_approx_options, len(b))
+        collect = lambda s, y, pcg_iter: inv_hess_collector.update(s, y, pcg_iter)
+    else:
+        collect = lambda s, y, pcg_iter: None
+
+    A, M, x, b, postprocess = make_system(A, M, x0, b)
+    bnrm2 = np.linalg.norm(b)
+
+    atol = max(float(atol), float(rtol) * float(bnrm2))
+
+    if bnrm2 == 0:
+        return postprocess(b), 0
+
+    n = len(b)
+
+    if maxiter is None:
+        maxiter = n*10
+
+    dotprod = np.dot
+
+    matvec = A.matvec
+    psolve = M.matvec
+    r = b - matvec(x) if x.any() else b.copy()
+
+    rho_prev, p = None, None
+
+    for iteration in range(maxiter):
+        if np.linalg.norm(r) < atol:
+            return postprocess(x), 0
+
+        z = psolve(r)
+        rho_cur = dotprod(r, z)
+        if iteration > 0:
+            beta = rho_cur / rho_prev
+            p *= beta
+            p += z
+        else:
+            p = np.empty_like(r)
+            p[:] = z[:]
+
+        q = matvec(p)
+        alpha = rho_cur / dotprod(p, q)
+        x += alpha*p
+        r -= alpha*q
+        rho_prev = rho_cur
+
+        collect(alpha*p, -alpha*q, iteration)
+        if callback:
+            callback(x)
+
+    else:
+        return postprocess(x), maxiter
+    
+
+

--- a/parapint/linalg/iterative/tests/test_pcg.py
+++ b/parapint/linalg/iterative/tests/test_pcg.py
@@ -1,12 +1,7 @@
-import unittest
 import parapint
 import pytest
-from pyomo.contrib.pynumero.sparse import BlockMatrix, BlockVector
-from parapint.linalg import ScipyInterface
 import scipy.sparse as sps
-from scipy.sparse import coo_matrix
 import numpy as np
-import sys
 
 import parapint.linalg.iterative
 import parapint.linalg.iterative.pcg
@@ -118,9 +113,7 @@ def test_neg_curvature_detection(case):
     x0 = 0 * b
     pcg_options = parapint.linalg.PcgOptions()
     results = parapint.linalg.iterative.pcg.pcg_solve(A=A, b=b, x0=x0, pcg_options=pcg_options)
-
     assert results.status == parapint.linalg.iterative.pcg.PcgSolutionStatus.negative_curvature
-
 
 
 def test_hess_approx_collection_last():
@@ -199,40 +192,5 @@ def test_hess_approx_collection_uniform():
     assert np.allclose(hinv_approx.yk[-1, :], pcg_iter * np.ones(n) * (1/3))
 
 
-# def test_hess_approx_accuracy(test_case):
-#     if not test_case.expected_status == parapint.linalg.iterative.pcg.PcgSolutionStatus.successful:
-#         pytest.skip("Skipped test which is expected to fail")
-#     A = test_case.A
-#     rtol = 1e-8
-#     atol = 1e-8
-#     b = test_case.b
-#     x0 = 0 * b
-
-#     lbfgs_approx_options = parapint.linalg.iterative.pcg.LbfgsApproxOptions()
-#     lbfgs_approx_options.m = 31
-#     lbfgs_approx_options.sampling = parapint.linalg.iterative.pcg.LbfgsSamplingOptions.uniform
-
-#     pcg_options = parapint.linalg.PcgOptions()
-#     pcg_options.lbfgs_approx_options = lbfgs_approx_options
-#     pcg_options.rtol = rtol
-#     pcg_options.atol = atol
-
-#     results = parapint.linalg.iterative.pcg.pcg_solve(A=A, b=b, x0=x0, pcg_options=pcg_options)
-#     hess_approx = results.hess_approx.todense()
-
-#     #true_inv = np.linalg.inv(A)
-
-#     M = hess_approx @ A
-#     # Not a very good test - is there a case to get exact inverse from l-bfgs hess approx?
-#     dense_A = A.todense() if sps.isspmatrix(A) else A
-#     assert np.linalg.cond(M) < np.linalg.cond(dense_A)
-
-
-
 if __name__ == '__main__':
-    # execute pytest for this file
     pytest.main(['-v', __file__])
-
-
-
-

--- a/parapint/linalg/iterative/tests/test_pcg.py
+++ b/parapint/linalg/iterative/tests/test_pcg.py
@@ -88,10 +88,147 @@ def test_maxiter(test_case):
     assert results.num_iterations == 1
 
 
+def test_residual(test_case):
+    if not test_case.expected_status == parapint.linalg.iterative.pcg.PcgSolutionStatus.successful:
+        pytest.skip("Skipped test which is expected to fail")
+    A = test_case.A
+    rtol = 1e-8
+    atol = 1e-8
+    b = test_case.b
+    x0 = 0 * b
+
+    pcg_options = parapint.linalg.PcgOptions()
+    pcg_options.rtol = rtol
+    pcg_options.atol = atol
+
+    results = parapint.linalg.iterative.pcg.pcg_solve(A=A, b=b, x0=x0, pcg_options=pcg_options)
+
+    residual = np.linalg.norm(A.dot(results.x) - b)
+    assert residual < max(atol, rtol * np.linalg.norm(b))
+
+
+neg_curvature_cases = [x for x in test_cases
+                        if x.expected_status == parapint.linalg.iterative.pcg.PcgSolutionStatus.negative_curvature]
+@pytest.mark.parametrize('case', neg_curvature_cases, ids=[x.name for x in neg_curvature_cases])
+def test_neg_curvature_detection(case):
+    # if not case.expected_status == parapint.linalg.iterative.pcg.PcgSolutionStatus.negative_curvature:
+    #     pytest.skip("Skipped test which is expected to fail")
+    A = case.A
+    b = case.b
+    x0 = 0 * b
+    pcg_options = parapint.linalg.PcgOptions()
+    results = parapint.linalg.iterative.pcg.pcg_solve(A=A, b=b, x0=x0, pcg_options=pcg_options)
+
+    assert results.status == parapint.linalg.iterative.pcg.PcgSolutionStatus.negative_curvature
+
+
+
+def test_hess_approx_collection_last():
+    lbfgs_approx_options = parapint.linalg.iterative.pcg.LbfgsApproxOptions()
+    lbfgs_approx_options.m = 3
+    lbfgs_approx_options.sampling = parapint.linalg.iterative.pcg.LbfgsSamplingOptions.last
+
+    n = 20
+    hinv_collector = parapint.linalg.iterative.pcg.LbfgsInvHessCollector(approx_options=lbfgs_approx_options, dim=n)
+    n_iter = 10
+    for pcg_iter in range(1, n_iter):
+        s = pcg_iter * np.ones(n)
+        y = pcg_iter * np.ones(n) * (1/3)
+        hinv_collector.update(s, y)
+
+    hinv_approx = hinv_collector.pop_inv_hessian_approx()
+
+    assert np.allclose(hinv_approx.sk[-1, :], pcg_iter * np.ones(n))
+    assert np.allclose(hinv_approx.yk[-1, :], pcg_iter * np.ones(n) * (1/3))
+    assert np.allclose(hinv_approx.sk[-2, :], (pcg_iter - 1) * np.ones(n))
+    assert np.allclose(hinv_approx.yk[-2, :], (pcg_iter - 1) * np.ones(n) * (1/3))
+    assert np.allclose(hinv_approx.sk[-3, :], (pcg_iter - 2) * np.ones(n))
+    assert np.allclose(hinv_approx.yk[-3, :], (pcg_iter - 2) * np.ones(n) * (1/3))
+
+
+def test_hess_approx_collection_first():
+    lbfgs_approx_options = parapint.linalg.iterative.pcg.LbfgsApproxOptions()
+    lbfgs_approx_options.m = 3
+    lbfgs_approx_options.sampling = parapint.linalg.iterative.pcg.LbfgsSamplingOptions.first
+
+    n = 20
+    hinv_collector = parapint.linalg.iterative.pcg.LbfgsInvHessCollector(approx_options=lbfgs_approx_options, dim=n)
+    n_iter = 10
+    for pcg_iter in range(1, n_iter):
+        s = pcg_iter * np.ones(n)
+        y = pcg_iter * np.ones(n) * (1/3)
+        hinv_collector.update(s, y)
+
+    hinv_approx = hinv_collector.pop_inv_hessian_approx()
+
+    assert np.allclose(hinv_approx.sk[0, :], 1 * np.ones(n))
+    assert np.allclose(hinv_approx.yk[0, :], 1 * np.ones(n) * (1/3))
+    assert np.allclose(hinv_approx.sk[1, :], 2 * np.ones(n))
+    assert np.allclose(hinv_approx.yk[1, :], 2 * np.ones(n) * (1/3))
+    # last iterate is always collected
+    assert np.allclose(hinv_approx.sk[-1, :], pcg_iter * np.ones(n))
+    assert np.allclose(hinv_approx.yk[-1, :], pcg_iter * np.ones(n) * (1/3))
+
+
+def test_hess_approx_collection_uniform():
+    lbfgs_approx_options = parapint.linalg.iterative.pcg.LbfgsApproxOptions()
+    lbfgs_approx_options.m = 11
+    lbfgs_approx_options.sampling = parapint.linalg.iterative.pcg.LbfgsSamplingOptions.uniform
+
+    target_cycle = 2
+    exititer = ((lbfgs_approx_options.m - 1) - 1) * (2 ** target_cycle)
+    n = 20
+    hinv_collector = parapint.linalg.iterative.pcg.LbfgsInvHessCollector(approx_options=lbfgs_approx_options, dim=n)
+    # iterate to include exititer calls to collect
+    for pcg_iter in range(1, exititer + 1):
+        s = pcg_iter * np.ones(n)
+        y = pcg_iter * np.ones(n) * (1/3)
+        hinv_collector.update(s, y)
+
+    hinv_approx = hinv_collector.pop_inv_hessian_approx()
+
+    # check uniform samples
+    print(hinv_collector._k_indxs)
+    assert np.allclose(np.array(hinv_collector._k_indxs), np.linspace(0, exititer, lbfgs_approx_options.m - 1, dtype=int)), 'Uniform samples not collected correctly'
+    # check that correct samples were stored
+    for i in range(lbfgs_approx_options.m - 1):
+        assert np.allclose(hinv_approx.sk[i], (hinv_collector._k_indxs[i] + 1) * np.ones(n))
+        assert np.allclose(hinv_approx.yk[i], (hinv_collector._k_indxs[i] + 1) * np.ones(n) * (1/3))
+    # last iterate is always collected
+    assert np.allclose(hinv_approx.sk[-1, :], pcg_iter * np.ones(n))
+    assert np.allclose(hinv_approx.yk[-1, :], pcg_iter * np.ones(n) * (1/3))
+
+
+def test_hess_approx_accuracy(test_case):
+    if not test_case.expected_status == parapint.linalg.iterative.pcg.PcgSolutionStatus.successful:
+        pytest.skip("Skipped test which is expected to fail")
+    A = test_case.A
+    rtol = 1e-8
+    atol = 1e-8
+    b = test_case.b
+    x0 = 0 * b
+
+    lbfgs_approx_options = parapint.linalg.iterative.pcg.LbfgsApproxOptions()
+    lbfgs_approx_options.m = 11
+    lbfgs_approx_options.sampling = parapint.linalg.iterative.pcg.LbfgsSamplingOptions.uniform
+
+    pcg_options = parapint.linalg.PcgOptions()
+    pcg_options.lbfgs_approx_options = lbfgs_approx_options
+    pcg_options.rtol = rtol
+    pcg_options.atol = atol
+
+    results = parapint.linalg.iterative.pcg.pcg_solve(A=A, b=b, x0=x0, pcg_options=pcg_options)
+    hess_approx = results.hess_approx.todense()
+
+    true_inv = np.linalg.inv(A.toarray())
+
+    assert np.allclose(hess_approx, true_inv, rtol=1e-2, atol=1e-2)
+
 
 if __name__ == '__main__':
     # execute pytest for this file
-    pytest.main(['-v', __file__])
+    #pytest.main(['-v', __file__])
+    test_hess_approx_collection_uniform()
 
 
 

--- a/parapint/linalg/iterative/tests/test_pcg.py
+++ b/parapint/linalg/iterative/tests/test_pcg.py
@@ -1,0 +1,97 @@
+import unittest
+import parapint
+import pytest
+from pyomo.contrib.pynumero.sparse import BlockMatrix, BlockVector
+from parapint.linalg import ScipyInterface
+import scipy.sparse as sps
+from scipy.sparse import coo_matrix
+import numpy as np
+import sys
+
+import parapint.linalg.iterative
+import parapint.linalg.iterative.pcg
+
+# Test suite in part taken from sps.linalg._isolve.tests.test_iterative.py
+
+class LinearTestSystem:
+    def __init__(self,
+                 name,
+                 A,
+                 b=None,
+                 expected_status=None,
+                 ):
+        self.name = name
+        self.A = A
+        if b is None:
+            self.b = np.arange(A.shape[0], dtype=float)
+        else:
+            self.b = b
+        if expected_status is None:
+            self.expected_status = parapint.linalg.iterative.pcg.PcgSolutionStatus.successful
+        else:
+            self.expected_status = expected_status
+
+def generate_test_systems():
+    cases = []
+    # Test systems
+    N = 40
+    data = np.ones((3, N))
+    data[0, :] = 2
+    data[1, :] = -1
+    data[2, :] = -1
+    Poisson1D = sps.spdiags(data, [0, -1, 1], N, N, format='csr')
+    cases.append(LinearTestSystem('Poisson1D', A=Poisson1D))
+
+    Poisson2D = sps.kronsum(Poisson1D, Poisson1D)
+    cases.append(LinearTestSystem('Poisson2D', A=Poisson2D))
+
+    np.random.seed(1234)
+    data = np.random.rand(N, N)
+    data = np.dot(data.conj(), data.T)
+    cases.append(LinearTestSystem('RandomPD', A=data))
+
+    A = np.array([[1, 1, 0, 0, 0, 0, 0, 0],
+                [0, 1, 0, 0, 0, 0,-1, 0],
+                [0, 0, 1, 0, 0, 0,-1, 0],
+                [0, 0, 0, 1, 0, 0, 0,-1],
+                [0, 0, 0, 0, 1, 0, 0,-1],
+                [0, 0, 0, 0, 0, 1, 0, 0],
+                [0,-1,-1, 0, 0, 0, 0, 0],
+                [0, 0, 0,-1,-1, 0, 0, 0],
+                ], dtype=np.double)
+    
+    cases.append(LinearTestSystem('SymIndef', A=A,
+                                  expected_status=parapint.linalg.iterative.pcg.PcgSolutionStatus.negative_curvature))
+
+    return cases
+
+test_cases = generate_test_systems()
+
+@pytest.fixture(params=test_cases, ids=[x.name for x in test_cases])
+def test_case(request):
+    return request.param
+
+def test_maxiter(test_case):
+    if test_case.expected_status == parapint.linalg.iterative.pcg.PcgSolutionStatus.negative_curvature:
+        pytest.skip("Skipped test which terminates at unpredictable iteration count")
+    A = test_case.A
+    rtol = 1e-12
+    b = test_case.b
+    x0 = 0 * b
+
+    pcg_options = parapint.linalg.PcgOptions()
+    pcg_options.max_iter = 1
+    pcg_options.rtol = rtol
+
+    results = parapint.linalg.iterative.pcg.pcg_solve(A=A, b=b, x0=x0, pcg_options=pcg_options)
+
+    assert results.num_iterations == 1
+
+
+
+if __name__ == '__main__':
+    # execute pytest for this file
+    pytest.main(['-v', __file__])
+
+
+


### PR DESCRIPTION
Added implementation of PCG with tests.

Implementation largely from scipy, with addition of 
- L-BFGS hessian inverse approximations
- termination for negative curvature
- some custom classes for options etc.

This will be used for implicit Schur decomposition. 