### PR TITLE
fixed tril/triu behavior for mkl test, minor formatting

### DIFF
--- a/parapint/linalg/mkl_pardiso_interface.py
+++ b/parapint/linalg/mkl_pardiso_interface.py
@@ -22,7 +22,7 @@ class InteriorPointMKLPardisoInterface(LinearSolverInterface):
     @classmethod
     def getLoggerName(cls):
         return 'mkl_pardiso'
-    
+
     def _convert_matrix(self, matrix: Union[spmatrix, BlockMatrix]
                         ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         if isinstance(matrix, BlockMatrix):
@@ -66,8 +66,6 @@ class InteriorPointMKLPardisoInterface(LinearSolverInterface):
             else:
                 res.status = LinearSolverStatus.error
         return res
-    
-
 
     def do_numeric_factorization(
         self, matrix: Union[spmatrix, BlockMatrix], raise_on_error: bool = True
@@ -101,9 +99,7 @@ class InteriorPointMKLPardisoInterface(LinearSolverInterface):
         self._num_status = res.status
 
         return res
-    
 
-    
     def increase_memory_allocation(self, factor):
         raise NotImplementedError("increase_memory_allocation not implemented for MKL Pardiso")
 
@@ -114,7 +110,7 @@ class InteriorPointMKLPardisoInterface(LinearSolverInterface):
             raise RuntimeError('Must call do_numeric_factorization before do_back_solve can be called')
         if self._num_status != LinearSolverStatus.successful:
             raise RuntimeError('Can only call do_back_solve if the numeric factorization was successful.')
-        
+
         if isinstance(rhs, BlockVector):
             _rhs = rhs.flatten()
             result = _rhs
@@ -144,14 +140,13 @@ class InteriorPointMKLPardisoInterface(LinearSolverInterface):
         num_negative_eigenvalues = self.get_iparm(23)
         num_positive_eigenvalues = self.get_iparm(22)
         return (num_positive_eigenvalues, num_negative_eigenvalues, 0)
-    
 
 
 class InteriorPointMKLPardisoSchurInterface(InteriorPointMKLPardisoInterface):
 
     def get_schur_complement(self):
         return self._pardiso.get_schur_complement()
-    
+
     def do_symbolic_factorization(
         self, matrix: Union[spmatrix, BlockMatrix], dim_schur: int, raise_on_error: bool = True
     ) -> LinearSolverResults:
@@ -164,7 +159,7 @@ class InteriorPointMKLPardisoSchurInterface(InteriorPointMKLPardisoInterface):
         _a, _ia, _ja = self._convert_matrix(matrix)
 
         stat = self._pardiso.do_symbolic_factorization_schur(a=_a, ia=_ia, ja=_ja, dim_schur=dim_schur)
-        
+
         res = LinearSolverResults()
         if stat == 0:
             res.status = LinearSolverStatus.successful
@@ -182,7 +177,7 @@ class InteriorPointMKLPardisoSchurInterface(InteriorPointMKLPardisoInterface):
                 res.status = LinearSolverStatus.error
 
         return res
-    
+
     def do_numeric_factorization(
         self, matrix: Union[spmatrix, BlockMatrix], raise_on_error: bool = True
     ) -> LinearSolverResults:
@@ -223,7 +218,7 @@ class InteriorPointMKLPardisoSchurInterface(InteriorPointMKLPardisoInterface):
             raise RuntimeError('Must call do_numeric_factorization before do_back_solve can be called')
         if self._num_status != LinearSolverStatus.successful:
             raise RuntimeError('Can only call do_back_solve if the numeric factorization was successful.')
-        
+
         if isinstance(rhs, BlockVector):
             _rhs = rhs.flatten()
             result = _rhs

--- a/parapint/linalg/tests/test_linear_solvers.py
+++ b/parapint/linalg/tests/test_linear_solvers.py
@@ -1,12 +1,14 @@
-import unittest
-from pyomo.common.dependencies import attempt_import
-import numpy as np
-import scipy.sparse as sps
-from scipy.sparse import coo_matrix, tril
-import parapint
-import pytest
 import os
+import unittest
+
+import numpy as np
+import pytest
+import scipy.sparse as sps
+from pyomo.common.dependencies import attempt_import
 from pyomo.contrib.pynumero.linalg.ma27 import MA27Interface
+from scipy.sparse import coo_matrix, tril
+
+import parapint
 from parapint.linalg.mkl_pardiso import MKLPardisoInterface
 
 ma27_available = MA27Interface.available()
@@ -54,7 +56,7 @@ def get_schur_complement_matrices(n=10, m=5, seed=0):
     A[:n, n:] = B.A
     A[n:, :n] = B.A.T
     A[n:, n:] = D
-    
+
     S = D - B.T @ np.linalg.inv(H) @ B
 
     A = coo_matrix(A)
@@ -153,7 +155,6 @@ class TestLinearSolvers(unittest.TestCase):
         self._test_inertia_computation(solver)
 
 
-@unittest.skip('This does not work yet')
 class TestWrongNonzeroOrdering(unittest.TestCase):
     def _test_solvers(self, solver, use_tril):
         mat = get_base_matrix(use_tril=use_tril)

--- a/parapint/linalg/tests/test_linear_solvers.py
+++ b/parapint/linalg/tests/test_linear_solvers.py
@@ -168,14 +168,14 @@ class TestWrongNonzeroOrdering(unittest.TestCase):
     @pytest.mark.fast
     def test_scipy(self):
         solver = parapint.linalg.ScipyInterface()
-        self._test_solvers(solver, use_tril=True)
+        self._test_solvers(solver, use_tril=False)
 
     @pytest.mark.serial
     @pytest.mark.fast
     @unittest.skipIf(not mumps_available, 'mumps is needed for interior point mumps tests')
     def test_mumps(self):
         solver = parapint.linalg.MumpsInterface()
-        self._test_solvers(solver, use_tril=True)
+        self._test_solvers(solver, use_tril=False)
 
     @pytest.mark.serial
     @pytest.mark.fast
@@ -189,7 +189,7 @@ class TestWrongNonzeroOrdering(unittest.TestCase):
     @unittest.skipIf(not mkl_pardiso_available, 'MKL Pardiso is needed for interior point MKL Pardiso tests')
     def test_mkl_pardiso(self):
         solver = parapint.linalg.InteriorPointMKLPardisoInterface()
-        self._test_solvers(solver, use_tril=True)
+        self._test_solvers(solver, use_tril=False)
 
 
 class TestSchurComplementSolver(unittest.TestCase):


### PR DESCRIPTION
Fixed a failed test when using Pardiso. It occured because Pardiso expects an upper triangular matrix, so setting `use_tril=True` results in only the diagonal being read. I set `use_tril=False` for all tests, since this should probably be the default behavior, where each interface then reads the lower/upper triangular part depending on what the underlying solver expects. 